### PR TITLE
Added router "singleapp" param and prevent [object][Object] in links

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -109,7 +109,20 @@ Generator.prototype.attach = function (options) {
             var pval = (pConfig.enabled && params[pName]) ? params[pName] : pConfig.default;
             
             if (pval) {
-              uri.pathname += '/' + pConfig.regex.replace(/\(.*\)/, pval);
+                
+                if(_.isObject(pval)){
+                   
+                    var segment = '';
+                   
+                    _.each(pval, function(val, kat){
+                        segment += kat + "-" + val + "/";
+                    });
+                   
+                    uri.pathname += '/' + pConfig.regex.replace(/\(.*\)/, segment);
+                   
+                }else{
+                    uri.pathname += '/' + pConfig.regex.replace(/\(.*\)/, pval);
+                }
             }
           }
         }


### PR DESCRIPTION
- added router "singleapp" param for support single app links, without protocol, hostname and port
- added support for links when "pName" have more than one parameters and "pval" is not just one value.
  fix for links like www.test.com/cars/[object][Object]
