### PR TITLE
Updated so the query parameter value of zero is valid.

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -80,7 +80,7 @@ module.exports = BasePlugin.extend({
 
           // replace capturing group with value
           var qval = (params.hasOwnProperty(key) && params[key] !== null) ? params[key] : param['default'];
-          if (qval) {
+          if (typeof(qval) !== "undefined") {
             uri.query[key] = param.regex.source.replace(/\(.*\)/, qval);
           }
         }


### PR DESCRIPTION
Currently, if a query param's value is numeric zero - it will not be included in a formatted URL.

This fixes the issue by explicitly testing qval.